### PR TITLE
Fix to forcibly close offcanvas by resizing if window size is larger than breakpoint.

### DIFF
--- a/src/hiraku.js
+++ b/src/hiraku.js
@@ -25,7 +25,7 @@
 		$('.js-hiraku-offcanvas').each(function() {
 			var $this = $(this);
 			var breakpoint = $(this).data('breakpoint');
-			if ($this.hasClass('js-hiraku-offcanvas-open')) {
+			if ($this.hasClass('js-hiraku-offcanvas-open') && (breakpoint === -1 || breakpoint >= window.innerWidth)) {
 				return;
 			}
 			if (breakpoint === -1 || breakpoint >= window.innerWidth) {
@@ -35,7 +35,8 @@
 			} else {
 				$this
 					.removeClass('js-hiraku-offcanvas-active')
-					.attr('aria-hidden', false);
+					.attr('aria-hidden', false)
+					.trigger('click');
 			}
 		});
 	};


### PR DESCRIPTION
ブレイクポイントの指定ありで初期化後、offcanvas メニューを開いたままブレイクポイントよりも大きな幅にリサイズされたとき、強制的にメニューを閉じた方が使いやすいと思いましたのでリクエストを送ります。